### PR TITLE
9 improving get metadata

### DIFF
--- a/{{ cookiecutter.__repo_name }}/tests/test_api.py
+++ b/{{ cookiecutter.__repo_name }}/tests/test_api.py
@@ -30,14 +30,14 @@ class TestModelMethods(unittest.TestCase):
         Test that get_metadata() returns right values (subset)
         """
         self.assertEqual(
-            self.meta["name"].lower().replace("-", "_"),
+            self.meta["Name"].lower().replace("-", "_"),
             "{{ cookiecutter.__app_name }}".lower().replace("-", "_"),
         )
         self.assertEqual(
-            self.meta["author"], "{{ cookiecutter.author_name }}".replace(", ", ",").split(",")
+            self.meta["Authors"], "{{ cookiecutter.author_name }}".replace(", ", ",").split(",")
         )
         self.assertEqual(
-            self.meta["license"].lower(),
+            self.meta["License"].lower(),
             "{{ cookiecutter.open_source_license }}".lower(),
         )
 

--- a/{{ cookiecutter.__repo_name }}/{{ cookiecutter.__app_name }}/api.py
+++ b/{{ cookiecutter.__repo_name }}/{{ cookiecutter.__app_name }}/api.py
@@ -50,14 +50,8 @@ def get_metadata():
     """
     try:  # Call your AI model metadata() method
         logger.info("Collecting metadata from: %s", config.API_NAME)
-        metadata = {
-            "name": config.API_METADATA.get("name"),
-            "author": config.API_METADATA.get("authors"),
-            "author-email": config.API_METADATA.get("author-emails"),
-            "description": config.API_METADATA.get("summary"),
-            "license": config.API_METADATA.get("license"),
-            "version": config.API_METADATA.get("version"),
-        }
+        metadata = config.API_METADATA
+        # TODO: Add dynamic metadata collection here
         logger.debug("Package model metadata: %s", metadata)
         return metadata
     except Exception as err:

--- a/{{ cookiecutter.__repo_name }}/{{ cookiecutter.__app_name }}/config.py
+++ b/{{ cookiecutter.__repo_name }}/{{ cookiecutter.__app_name }}/config.py
@@ -30,7 +30,7 @@ PROJECT_METADATA["Authors"] = sorted(_AUTHORS)
 
 # Get ai4-metadata.yaml metadata
 AI4_METADATA_DIR = os.getenv(
-    "AI4_METADATA_DIR",
+    f"{API_NAME.capitalize()}_AI4_METADATA_DIR",
     default=f"{os.getcwd()}/../{API_NAME}",
 )
 with open(f"{AI4_METADATA_DIR}/ai4-metadata.yml", "r", encoding="utf-8") as stream:

--- a/{{ cookiecutter.__repo_name }}/{{ cookiecutter.__app_name }}/config.py
+++ b/{{ cookiecutter.__repo_name }}/{{ cookiecutter.__app_name }}/config.py
@@ -10,20 +10,34 @@ import logging
 import os
 from importlib import metadata
 
-# Get AI model metadata
+import yaml
+
+
+# Get AI model metadata from pyproject.toml
 API_NAME = "{{ cookiecutter.__app_name }}"
-API_METADATA = metadata.metadata(API_NAME)  # .json
+PROJECT_METADATA = metadata.metadata(API_NAME)  # .json
 
 # Fix metadata for emails from pyproject parsing
-_EMAILS = API_METADATA["Author-email"].split(", ")
+_EMAILS = PROJECT_METADATA["Author-email"].split(", ")
 _EMAILS = map(lambda s: s[:-1].split(" <"), _EMAILS)
-API_METADATA["Author-emails"] = dict(_EMAILS)
+PROJECT_METADATA["Author-emails"] = dict(_EMAILS)
 
 # Fix metadata for authors from pyproject parsing
-_AUTHORS = API_METADATA.get("Author", "").replace(", ", ",").split(",")
+_AUTHORS = PROJECT_METADATA.get("Author", "").replace(", ", ",").split(",")
 _AUTHORS = [] if _AUTHORS == [""] else _AUTHORS
-_AUTHORS += API_METADATA["Author-emails"].keys()
-API_METADATA["Authors"] = sorted(_AUTHORS)
+_AUTHORS += PROJECT_METADATA["Author-emails"].keys()
+PROJECT_METADATA["Authors"] = sorted(_AUTHORS)
+
+# Get ai4-metadata.yaml metadata
+AI4_METADATA_DIR = os.getenv(
+    "AI4_METADATA_DIR",
+    default=f"{os.getcwd()}/../{API_NAME}",
+)
+with open(f"{AI4_METADATA_DIR}/ai4-metadata.yml", "r", encoding="utf-8") as stream:
+    AI4_METADATA = yaml.safe_load(stream)
+
+# Merge metadata from pyproject.toml and ai4-metadata.yml
+API_METADATA = {**PROJECT_METADATA, **AI4_METADATA}
 
 # logging level across API modules can be setup via API_LOG_LEVEL,
 # options: DEBUG, INFO(default), WARNING, ERROR, CRITICAL


### PR DESCRIPTION
This PR generates a env variable `{NAME}_AI4_METADATA_DIR` where user can define the dir containing the "ai4-metadata.yml" file. By default it takes `{os.getcwd()}/../{API_NAME}`, preventing conflict between multiple installed packages.

However, it bases it location acorting the CWD, so to work by default (without defining the env) that all projects are located in the same folder so the route works.

Please, also check the tests, as I have not implemented lowercase call. Please let me know if I should run "lowercase()" on API_METADATA keys.